### PR TITLE
Allow external-content to be used with v3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,6 @@
 		"email": "marcus@silverstripe.com.au"
 	}],
 	"require": {
-		"silverstripe/framework": "3.*"
+		"silverstripe/framework": ">=3.0.0"
 	}
 }


### PR DESCRIPTION
dev-master isn't included in the constraint "3.*" so I relaxed the constraint to ">=3.0.0"
