### PR TITLE
FIX: Fixed ID encoding.

### DIFF
--- a/code/model/ExternalContentSource.php
+++ b/code/model/ExternalContentSource.php
@@ -243,7 +243,10 @@ class ExternalContentSource extends DataObject {
 	 * 			A safely encoded ID
 	 */
 	public function encodeId($id) {
-		return str_replace('=', '-', base64_encode($id));
+		return str_replace(
+			array('=', '/', '+'),
+			array('-', '~' ,','),
+			base64_encode($id));
 	}
 
 	/**
@@ -255,7 +258,10 @@ class ExternalContentSource extends DataObject {
 	 * 			A decoded ID
 	 */
 	public function decodeId($id) {
-		$id = str_replace('-', '=', $id);
+		$id= str_replace(
+			array('-', '~' ,','),
+			array('=', '/', '+'),
+			$id);
 		return base64_decode($id);
 	}
 


### PR DESCRIPTION
The module uses base64 encoding to make arbitrary IDs safe.  However, / and + characters break this.   This patch to both encodeId and decodeId does a bit more sanitisation, to make sure that base64 doesn't return any nasty characters into the resulting IDs.
