### PR TITLE
Check request first before updatetreenodes.

### DIFF
--- a/code/controllers/ExternalContentAdmin.php
+++ b/code/controllers/ExternalContentAdmin.php
@@ -674,6 +674,9 @@ class ExternalContentAdmin extends LeftAndMain implements CurrentPageIdentifier,
 	
 	public function updatetreenodes($request) {
 		// noop
+		if(!$request->getVar('ids')){
+            		return false;
+        	}
 		return parent::updatetreenodes($request);
 	}
 


### PR DESCRIPTION
Fix the problem when I created or removed an empty connector, it display fatal errors in SS as $ids is empty in the function.